### PR TITLE
polished makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,3 @@ dev-deps:
 
 clean:
 	go clean
-
-dist-clean:
-	rm -rf pkg src bin
-


### PR DESCRIPTION
- dist-clean task on makefile is not necessary as we use `go install` to build
