### PR TITLE
Basic AWS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /go/src/github.com/ernestio/router-adapter
 
 RUN make deps && go install
 
-ENTRYPOINT /go/bin/router-adapter
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "Waiting for NATS"
+while ! echo exit | nc nats 4222; do sleep 1; done
+
+echo "Waiting for Postgres"
+while ! echo exit | nc postgres 5432; do sleep 1; done
+
+echo "Starting router-adapter"
+/go/bin/router-adapter

--- a/main.go
+++ b/main.go
@@ -48,9 +48,10 @@ func main() {
 		ValidTypes: getConnectorTypes("routers"),
 	}
 
+	t := Translator{}
 	log.Println("Setting up routers")
-	o.StandardSubscription(&c, "router.create", "router_type")
-	o.StandardSubscription(&c, "router.delete", "router_type")
+	o.TranslatedSubscription(&c, "router.create", "router_type", t)
+	o.TranslatedSubscription(&c, "router.delete", "router_type", t)
 
 	runtime.Goexit()
 }

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 
 	t := Translator{}
 	log.Println("Setting up routers")
-	o.TranslatedSubscription(&c, "router.create", "router_type", t)
-	o.TranslatedSubscription(&c, "router.delete", "router_type", t)
+	o.TranslatedSubscription(&c, "router.create", "_type", t)
+	o.TranslatedSubscription(&c, "router.delete", "_type", t)
 
 	runtime.Goexit()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,7 @@ func TestBasicRedirections(t *testing.T) {
 		Convey("When it receives an invalid fake message", func() {
 			n.Publish("router.create", []byte(`{"service":"aaa"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
-				So(wait(cherr), ShouldNotBeNil)
+				So(wait(cherr), ShouldBeNil)
 			})
 		})
 		Convey("When it receives a valid fake message", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,8 @@ func TestBasicRedirections(t *testing.T) {
 		Convey("When it receives an invalid fake message", func() {
 			n.Publish("router.create", []byte(`{"service":"aaa"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
-				So(wait(cherr), ShouldBeNil)
+				e := wait(cherr)
+				So(e, ShouldNotBeNil)
 			})
 		})
 		Convey("When it receives a valid fake message", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -58,13 +58,13 @@ func TestBasicRedirections(t *testing.T) {
 			})
 		})
 		Convey("When it receives a valid fake message", func() {
-			n.Publish("router.create", []byte(`{"service":"aaa","router_type":"fake"}`))
+			n.Publish("router.create", []byte(`{"service":"aaa","type":"fake"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chfak), ShouldBeNil)
 			})
 		})
 		Convey("When it receives a valid vcloud message", func() {
-			n.Publish("router.create", []byte(`{"service":"aaa","router_type":"vcloud"}`))
+			n.Publish("router.create", []byte(`{"service":"aaa","type":"vcloud"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvcl), ShouldBeNil)
 			})

--- a/translator.go
+++ b/translator.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+type builderEvent struct {
+	Uuid               string `json:"_uuid"`
+	BatchID            string `json:"_batch_id"`
+	Service            string `json:"service"`
+	Name               string `json:"name"`
+	Type               string `json:"type"`
+	ClientName         string `json:"client_name"`
+	DatacenterName     string `json:"datacenter_name"`
+	DatacenterPassword string `json:"datacenter_password"`
+	DatacenterRegion   string `json:"datacenter_region"`
+	DatacenterType     string `json:"datacenter_type"`
+	DatacenterUsername string `json:"datacenter_username"`
+	ExternalNetwork    string `json:"external_network"`
+	VCloudURL          string `json:"vcloud_url"`
+	VseURL             string `json:"vse_url"`
+	IP                 string `json:"ip"`
+	Created            bool   `json:"created"`
+	Status             string `json:"status"`
+	ErrorCode          string `json:"error_code"`
+	ErrorMessage       string `json:"error_message"`
+}
+
+type vcloudEvent struct {
+	Uuid               string `json:"_uuid"`
+	BatchID            string `json:"_batch_id"`
+	Service            string `json:"service_id"`
+	Type               string `json:"type"`
+	RouterName         string `json:"router_name"`
+	RouterType         string `json:"router_type"`
+	RouterIP           string `json:"router_ip"`
+	ClientName         string `json:"client_name"`
+	DatacenterName     string `json:"datacenter_name"`
+	DatacenterUsername string `json:"datacenter_username"`
+	DatacenterPassword string `json:"datacenter_password"`
+	DatacenterRegion   string `json:"datacenter_region"`
+	DatacenterType     string `json:"datacenter_type"`
+	ExternalNetwork    string `json:"external_network"`
+	VCloudURL          string `json:"vcloud_url"`
+	VseURL             string `json:"vse_url"`
+	Status             string `json:"status"`
+}
+
+type Translator struct{}
+
+func (t Translator) BuilderToConnector(j []byte) []byte {
+	var input builderEvent
+	var output vcloudEvent
+
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.RouterName = input.Name
+	output.Service = input.Service
+	output.RouterType = input.Type
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterType = input.DatacenterType
+	output.ExternalNetwork = input.ExternalNetwork
+	output.VCloudURL = input.VCloudURL
+	output.VseURL = input.VseURL
+	output.Status = input.Status
+
+	body, _ := json.Marshal(output)
+	return body
+}
+
+func (t Translator) ConnectorToBuilder(j []byte) []byte {
+	var input vcloudEvent
+	var output builderEvent
+
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Name = input.RouterName
+	output.Service = input.Service
+	output.Type = input.RouterType
+	output.IP = input.RouterIP
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterType = input.DatacenterType
+	output.ExternalNetwork = input.ExternalNetwork
+	output.VCloudURL = input.VCloudURL
+	output.VseURL = input.VseURL
+	output.Status = input.Status
+
+	body, _ := json.Marshal(output)
+	return body
+}

--- a/translator.go
+++ b/translator.go
@@ -29,8 +29,8 @@ type builderEvent struct {
 type vcloudEvent struct {
 	Uuid               string `json:"_uuid"`
 	BatchID            string `json:"_batch_id"`
+	Type               string `json:"_type"`
 	Service            string `json:"service_id"`
-	Type               string `json:"type"`
 	RouterName         string `json:"router_name"`
 	RouterType         string `json:"router_type"`
 	RouterIP           string `json:"router_ip"`
@@ -56,6 +56,7 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
+	output.Type = input.Type
 	output.RouterName = input.Name
 	output.Service = input.Service
 	output.RouterType = input.Type

--- a/translator.go
+++ b/translator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"strconv"
 )
 
@@ -84,7 +85,10 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	var input vcloudEvent
 	var output builderEvent
 
-	json.Unmarshal(j, &input)
+	err := json.Unmarshal(j, &input)
+	if err != nil {
+		log.Println(err.Error())
+	}
 
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
@@ -105,6 +109,10 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	output.ErrorCode = strconv.Itoa(input.Error.Code)
 	output.ErrorMessage = input.Error.Message
 
-	body, _ := json.Marshal(output)
+	body, err := json.Marshal(output)
+	if err != nil {
+		log.Println(err.Error())
+	}
+
 	return body
 }

--- a/translator.go
+++ b/translator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 )
 
 type builderEvent struct {
@@ -44,6 +45,10 @@ type vcloudEvent struct {
 	VCloudURL          string `json:"vcloud_url"`
 	VseURL             string `json:"vse_url"`
 	Status             string `json:"status"`
+	Error              struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
 }
 
 type Translator struct{}
@@ -97,6 +102,8 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	output.VCloudURL = input.VCloudURL
 	output.VseURL = input.VseURL
 	output.Status = input.Status
+	output.ErrorCode = strconv.Itoa(input.Error.Code)
+	output.ErrorMessage = input.Error.Message
 
 	body, _ := json.Marshal(output)
 	return body


### PR DESCRIPTION
Adapters were conceived as the place to prepare an internal service to be consumed by a connector, so connectors can focus only on calling third party apis.

However they are quite dummy at the moment, they only get a message and redirect it to the consumer related to the provider.

The behaviour implemented here is:

- Have defined a connector mapping for each connector they support.
- Receive a message "component.process" with the related component partial of the service as this one.
- Call connector with a "component.process.provider"
- Receive a "component.process.provider.done" and map the result back to the partial of the service.
- And finally publish "component.process.done" with mapped partial.